### PR TITLE
Refactor: Implement robust HTTP-only cookie-based authentication

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -29,8 +29,8 @@ async function gerarRespostaComMySQL(user: any, accessToken: string, refreshToke
           email: user.email,
           role: user.role || 'user',
           avatar_url: user.avatar_url
-        },
-        accessToken: accessToken // Add accessToken to the response body
+        }
+        // accessToken: accessToken // REMOVED from response body
       },
       { status: 200 }
     );
@@ -74,8 +74,8 @@ async function gerarRespostaComMySQL(user: any, accessToken: string, refreshToke
           email: user.email,
           role: user.role || 'user',
           avatar_url: user.avatar_url
-        },
-        accessToken: accessToken // Also add to fallback response for consistency
+        }
+        // accessToken: accessToken // REMOVED from fallback response body
       },
       { status: 200 }
     );

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -91,8 +91,8 @@ export async function POST(request: NextRequest) { // Changed GET to POST
           email: user.email,
           role: user.role,
           avatar_url: user.avatar_url
-        },
-        accessToken: accessToken // Add accessToken to the response body
+        }
+        // accessToken: accessToken // REMOVED from response body
       },
       { status: 200 }
     );

--- a/app/api/documentos/doc/[id]/download/route.ts
+++ b/app/api/documentos/doc/[id]/download/route.ts
@@ -28,8 +28,19 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
   try {
     // 1. Authentication
-    const tokenPayload = await verifyJwtToken(request);
-    if (!tokenPayload) {
+    let token = request.cookies.get('accessToken')?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for GET /api/documentos/doc/[id]/download");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
+      return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
+    }
+    const tokenPayload = await verifyJwtToken(token); // Assuming verifyJwtToken takes a token string
+    if (!tokenPayload) { // verifyJwtToken might return null or throw, so check payload
       return NextResponse.json({ error: 'Não autorizado ou token inválido' }, { status: 401 });
     }
 

--- a/app/api/documentos/doc/[id]/route.ts
+++ b/app/api/documentos/doc/[id]/route.ts
@@ -57,11 +57,17 @@ export async function GET(request: NextRequest, { params }: PathParams) {
   console.log(`GET /api/documentos/doc/${documentoId} for licitacao ${licitacaoId} - MySQL`);
 
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for GET /api/documentos/doc/[id]");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token);
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });
@@ -118,11 +124,17 @@ export async function PATCH(request: NextRequest, { params }: PathParams) {
   console.log(`PATCH /api/documentos/doc/${documentoId} for licitacao ${licitacaoId} - MySQL`);
 
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for PATCH /api/documentos/doc/[id]");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token);
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });
@@ -231,11 +243,17 @@ export async function DELETE(request: NextRequest, { params }: PathParams) {
   const { id: licitacaoId, documentoId } = params; // Correctly name params
   console.log(`DELETE /api/documentos/doc/${documentoId} for licitacao ${licitacaoId} - MySQL`);
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for DELETE /api/documentos/doc/[id]");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token);
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });

--- a/app/api/documentos/doc/route.ts
+++ b/app/api/documentos/doc/route.ts
@@ -47,11 +47,17 @@ export async function GET(request: NextRequest) {
   let connection;
   console.log("GET /api/documentos/doc - Iniciando consulta com MySQL");
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for GET /api/documentos/doc");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token);
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });
@@ -122,11 +128,17 @@ export async function POST(request: NextRequest) {
   let connection;
   console.log("POST /api/documentos/doc - Iniciando criação com MySQL");
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for POST /api/documentos/doc");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token);
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });
@@ -226,11 +238,17 @@ export async function PATCH(request: NextRequest) {
   let connection;
   console.log("PATCH /api/documentos/doc - Iniciando atualização com MySQL");
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for PATCH /api/documentos/doc");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token); // Valida e decodifica
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });
@@ -329,11 +347,17 @@ export async function DELETE(request: NextRequest) {
   let connection;
   console.log("DELETE /api/documentos/doc - Iniciando exclusão com MySQL");
   try {
+    let token = request.cookies.get('accessToken')?.value;
     const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for DELETE /api/documentos/doc");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
       return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
     }
-    const token = authHeader.split(' ')[1];
     const decodedToken = await verifyJwtToken(token);
     if (!decodedToken || !decodedToken.userId) {
       return NextResponse.json({ error: 'Não autorizado: token inválido' }, { status: 401 });

--- a/app/api/documentos/doc/upload/route.ts
+++ b/app/api/documentos/doc/upload/route.ts
@@ -42,7 +42,18 @@ const formatDocumentForResponse = async (connection: any, documentId: string) =>
 export async function POST(request: NextRequest) {
   let connection;
   try {
-    const tokenPayload = await verifyJwtToken(request);
+    let token = request.cookies.get('accessToken')?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for POST /api/documentos/doc/upload");
+      token = authHeader.split(' ')[1];
+    }
+
+    if (!token) {
+      return NextResponse.json({ error: 'Não autorizado: token não fornecido' }, { status: 401 });
+    }
+    const tokenPayload = await verifyJwtToken(token); // Assuming verifyJwtToken takes a token string
     if (!tokenPayload || !tokenPayload.userId) {
       return NextResponse.json({ error: 'Não autorizado ou token inválido' }, { status: 401 });
     }

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -9,16 +9,22 @@ export async function GET(
 ) {
   try {
     // Verify user is authenticated
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for GET /api/users/[id]");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId) {
       return NextResponse.json(
@@ -67,16 +73,22 @@ export async function PUT(
 ) {
   try {
     // Verify user is authenticated
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for PUT /api/users/[id]");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId) {
       return NextResponse.json(
@@ -147,16 +159,22 @@ export async function DELETE(
 ) {
   try {
     // Verify user is authenticated and is admin
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for DELETE /api/users/[id]");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId) {
       return NextResponse.json(

--- a/app/api/users/preferences/route.ts
+++ b/app/api/users/preferences/route.ts
@@ -11,16 +11,22 @@ const supabase = createClient(supabaseUrl, supabaseKey);
 export async function PUT(request: NextRequest) {
   try {
     // Verify user is authenticated
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for PUT /api/users/preferences");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId) {
       return NextResponse.json(

--- a/app/api/users/profile/route.ts
+++ b/app/api/users/profile/route.ts
@@ -6,16 +6,22 @@ import { verifyJwtToken } from "@/lib/auth/jwt";
 export async function GET(request: NextRequest) {
   try {
     // Verificar autenticação
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for GET /api/users/profile");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId) {
       return NextResponse.json(
@@ -111,16 +117,22 @@ export async function GET(request: NextRequest) {
 export async function PUT(request: NextRequest) {
   try {
     // Verificar autenticação
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for PUT /api/users/profile");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId) {
       return NextResponse.json(

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -7,16 +7,22 @@ import bcrypt from "bcryptjs";
 export async function GET(request: NextRequest) {
   try {
     // Verificar se o usuário está autenticado
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for GET /api/users");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId || payload.role !== "admin") {
       return NextResponse.json(
@@ -53,16 +59,22 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     // Verificar se o usuário está autenticado como admin
-    const accessToken = request.cookies.get("accessToken")?.value;
+    let token = request.cookies.get("accessToken")?.value;
+    const authHeader = request.headers.get('authorization');
+
+    if (!token && authHeader && authHeader.startsWith('Bearer ')) {
+      console.log("Token not found in cookie, attempting to use Authorization header for POST /api/users");
+      token = authHeader.split(' ')[1];
+    }
     
-    if (!accessToken) {
+    if (!token) {
       return NextResponse.json(
-        { error: "Não autorizado" },
+        { error: "Não autorizado: token não fornecido" },
         { status: 401 }
       );
     }
     
-    const payload = await verifyJwtToken(accessToken);
+    const payload = await verifyJwtToken(token);
     
     if (!payload || !payload.userId || payload.role !== "admin") {
       return NextResponse.json(

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -53,17 +53,14 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   useEffect(() => {
     const checkAuth = async () => {
       try {
-        // 1. Tenta restaurar do localStorage
-        const accessToken = localStorage.getItem('accessToken');
+        // 1. Tenta restaurar user info do localStorage (otimismo)
         const userJson = localStorage.getItem('user');
-        if (accessToken && userJson) {
+        if (userJson) {
           setUser(JSON.parse(userJson));
-          setIsAuthenticated(true);
-          setLoading(false);
-          return;
+          // setIsAuthenticated(true); // Authentication will be confirmed by refreshToken or subsequent actions
         }
 
-        // 2. Se não houver no localStorage, tenta via refreshToken/cookie
+        // 2. Tenta via refreshToken/cookie para confirmar/estabelecer sessão
         const cookies = document.cookie.split(';');
         const refreshTokenCookie = cookies.find(cookie => cookie.trim().startsWith('refreshToken='));
         if (!refreshTokenCookie) {
@@ -105,7 +102,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
       setUser(data.user);
       setIsAuthenticated(true);
-      localStorage.setItem('accessToken', data.accessToken); // Store the new accessToken
+      // localStorage.setItem('accessToken', data.accessToken); // REMOVED
     } catch (error) {
       console.error("Erro ao renovar token:", error);
       setUser(null);
@@ -169,8 +166,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
       setUser(data.user);
       setIsAuthenticated(true);
-      localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('user', JSON.stringify(data.user));
+      // localStorage.setItem('accessToken', data.accessToken); // REMOVED
+      localStorage.setItem('user', JSON.stringify(data.user)); // User info can still be stored
       
       toast.success("Login realizado com sucesso!");
       router.push("/dashboard");

--- a/hooks/useDocuments.ts
+++ b/hooks/useDocuments.ts
@@ -53,22 +53,12 @@ export function useDocuments() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Função para obter o token de autenticação
-  const getAuthToken = () => {
-    return localStorage.getItem('accessToken');
-  };
-
   // Buscar todos os documentos ou filtrar
   const fetchDocuments = useCallback(async (filters?: DocumentFilter) => {
     setLoading(true);
     setError(null);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
-
       // Construir URL com parâmetros de filtro
       let url = '/api/documentos/doc';
       const params = new URLSearchParams();
@@ -87,8 +77,9 @@ export function useDocuments() {
 
       const response = await fetch(url, {
         method: 'GET',
+        credentials: 'include', // Add credentials: 'include'
         headers: {
-          'Authorization': `Bearer ${token}`,
+          // 'Authorization': `Bearer ${token}`, // Remove Authorization header
           'Content-Type': 'application/json'
         }
       });
@@ -116,15 +107,11 @@ export function useDocuments() {
     setError(null);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
-
       const response = await fetch(`/api/documentos/doc/${id}`, {
         method: 'GET',
+        credentials: 'include', // Add credentials: 'include'
         headers: {
-          'Authorization': `Bearer ${token}`,
+          // 'Authorization': `Bearer ${token}`, // Remove Authorization header
           'Content-Type': 'application/json'
         }
       });
@@ -150,13 +137,8 @@ export function useDocuments() {
     setLoading(true);
     setError(null);
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
-      
       // API /api/documentos/doc (POST) agora espera 'tags' como array de strings
-      // e outros campos relevantes como 'criadoPor' (userId)
+      // e outros campos relevantes como 'criadoPor' (userId) - backend will get from JWT
       const payload = {
         nome: documentData.nome,
         tipo: documentData.tipo,
@@ -165,15 +147,16 @@ export function useDocuments() {
         numeroDocumento: documentData.numeroDocumento,
         dataValidade: documentData.dataValidade, // API espera YYYY-MM-DD ou null
         tags: documentData.tags || [],
-        criadoPor: getAuthToken() ? JSON.parse(atob(getAuthToken()!.split('.')[1])).userId : null, // Exemplo, idealmente de um contexto de usuário
+        // criadoPor: getAuthToken() ? JSON.parse(atob(getAuthToken()!.split('.')[1])).userId : null, // REMOVED - Backend will handle
         status: documentData.status || 'ativo',
         categoriaLegado: documentData.categoriaLegado
       };
       
       const response = await fetch('/api/documentos/doc', {
         method: 'POST',
+        credentials: 'include', // Add credentials: 'include'
         headers: {
-          'Authorization': `Bearer ${token}`,
+          // 'Authorization': `Bearer ${token}`, // Remove Authorization header
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(payload)
@@ -207,11 +190,6 @@ export function useDocuments() {
     setError(null);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
-
       // Se não tiver arquivo, usar a função createDocument
       if (!documentData.arquivo) {
         const { arquivo, ...metadataOnly } = documentData;
@@ -235,23 +213,24 @@ export function useDocuments() {
       if (documentData.dataValidade) formData.append('dataValidade', documentData.dataValidade); // API espera YYYY-MM-DD
       // urlDocumento é placeholder, não precisa enviar
 
-      // Adicionar criadoPor (uploadPor na API de upload)
-      const decodedToken = getAuthToken() ? JSON.parse(atob(getAuthToken()!.split('.')[1])) : null;
-      if (decodedToken && decodedToken.userId) {
-        formData.append('uploadPor', decodedToken.userId);
-      } else {
-        console.warn("ID do usuário não encontrado para 'uploadPor'");
-        // Considerar lançar erro ou não enviar se for obrigatório
-      }
+      // Adicionar criadoPor (uploadPor na API de upload) - backend will handle
+      // const decodedToken = getAuthToken() ? JSON.parse(atob(getAuthToken()!.split('.')[1])) : null;
+      // if (decodedToken && decodedToken.userId) {
+      //   formData.append('uploadPor', decodedToken.userId);
+      // } else {
+      //   console.warn("ID do usuário não encontrado para 'uploadPor'");
+      //   // Considerar lançar erro ou não enviar se for obrigatório
+      // }
       if (documentData.status) formData.append('status', documentData.status);
       if (documentData.categoriaLegado) formData.append('categoria', documentData.categoriaLegado);
 
 
       const response = await fetch('/api/documentos/doc/upload', {
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`
-        },
+        credentials: 'include', // Add credentials: 'include'
+        // headers: { // Remove Authorization header - FormData sets Content-Type
+        //   'Authorization': `Bearer ${token}`
+        // },
         body: formData
       });
 
@@ -283,18 +262,14 @@ export function useDocuments() {
     setError(null);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
-
       // A API DELETE em /api/documentos/doc/[id] agora lida com o parâmetro 'fisicamente'
       const url = `/api/documentos/doc/${id}?fisicamente=${fisicamente}`;
 
       const response = await fetch(url, {
         method: 'DELETE',
+        credentials: 'include', // Add credentials: 'include'
         headers: {
-          'Authorization': `Bearer ${token}`,
+          // 'Authorization': `Bearer ${token}`, // Remove Authorization header
           // Content-Type não é usualmente necessário para DELETE se não houver corpo
         }
       });
@@ -330,11 +305,6 @@ export function useDocuments() {
     setError(null);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
-
       // Se houver arquivo, fazer upload e atualizar o documento
       if (updateData.arquivo) {
         // Buscar documento atual para obter outros dados
@@ -389,8 +359,9 @@ export function useDocuments() {
 
         const response = await fetch(apiUrl, {
           method: 'PATCH',
+          credentials: 'include', // Add credentials: 'include'
           headers: {
-            'Authorization': `Bearer ${token}`,
+            // 'Authorization': `Bearer ${token}`, // Remove Authorization header
             'Content-Type': 'application/json'
           },
           // Se usar PATCH em /api/documentos/doc, o ID deve estar no corpo.

--- a/hooks/useLicitacoes.ts
+++ b/hooks/useLicitacoes.ts
@@ -91,11 +91,6 @@ export function useLicitacoes() {
     // ... mais exemplos se necessário, seguindo a nova interface Licitacao
   ];
 
-  // Função para obter o token de autenticação
-  const getAuthToken = () => {
-    return localStorage.getItem('accessToken');
-  };
-
   // Buscar todas as licitações
   const fetchLicitacoes = useCallback(async () => {
     // Verificar se temos dados em cache recentes (menos de 5 minutos)
@@ -121,11 +116,12 @@ export function useLicitacoes() {
       
       // Tentar buscar da API em paralelo
       try {
-        const token = getAuthToken();
+        // const token = getAuthToken(); // REMOVED
         const response = await fetch('/api/licitacoes', {
           method: 'GET',
+          credentials: 'include', // ADDED
           headers: {
-            'Authorization': token ? `Bearer ${token}` : '',
+            // 'Authorization': token ? `Bearer ${token}` : '', // REMOVED
             'Content-Type': 'application/json'
           }
         });
@@ -198,15 +194,16 @@ export function useLicitacoes() {
     setError(null);
 
     try {
-      const token = getAuthToken();
-      if (!token) {
-        throw new Error('Não autenticado');
-      }
+      // const token = getAuthToken(); // REMOVED
+      // if (!token) { // REMOVED
+      //   throw new Error('Não autenticado');
+      // }
 
       const response = await fetch(`/api/licitacoes/${id}`, {
         method: 'GET',
+        credentials: 'include', // ADDED
         headers: {
-          'Authorization': `Bearer ${token}`,
+          // 'Authorization': `Bearer ${token}`, // REMOVED
           'Content-Type': 'application/json'
         }
       });
@@ -232,12 +229,13 @@ export function useLicitacoes() {
     setLoading(true);
     setError(null);
     try {
-      const token = getAuthToken();
+      // const token = getAuthToken(); // REMOVED
       const response = await fetch('/api/licitacoes', {
         method: 'POST',
+        credentials: 'include', // ADDED
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': token ? `Bearer ${token}` : '',
+          // 'Authorization': token ? `Bearer ${token}` : '', // REMOVED
         },
         body: JSON.stringify(licitacaoData),
       });
@@ -262,12 +260,13 @@ export function useLicitacoes() {
     setLoading(true);
     setError(null);
     try {
-      const token = getAuthToken();
+      // const token = getAuthToken(); // REMOVED
       const response = await fetch(`/api/licitacoes/${id}`, {
         method: 'PUT',
+        credentials: 'include', // ADDED
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': token ? `Bearer ${token}` : '',
+          // 'Authorization': token ? `Bearer ${token}` : '', // REMOVED
         },
         body: JSON.stringify(licitacaoData),
       });
@@ -292,11 +291,12 @@ export function useLicitacoes() {
     setLoading(true);
     setError(null);
     try {
-      const token = getAuthToken();
+      // const token = getAuthToken(); // REMOVED
       const response = await fetch(`/api/licitacoes/${id}`, {
         method: 'DELETE',
+        credentials: 'include', // ADDED
         headers: {
-          'Authorization': token ? `Bearer ${token}` : '',
+          // 'Authorization': token ? `Bearer ${token}` : '', // REMOVED
         },
       });
       if (!response.ok) {

--- a/hooks/useLicitacoesOtimizado.ts
+++ b/hooks/useLicitacoesOtimizado.ts
@@ -190,16 +190,17 @@ export function useLicitacoesOtimizado() {
             if (filtros.valorMaximo) params.append('valorMax', filtros.valorMaximo.toString());
           }
           
-          // Obter token de autenticau00e7u00e3o
-          const accessToken = localStorage.getItem('accessToken');
+          // Obter token de autenticau00e7u00e3o - REMOVED
+          // const accessToken = localStorage.getItem('accessToken');
           
           console.log('Buscando licitau00e7u00f5es com paru00e2metros:', params.toString());
           const response = await fetch(`/api/licitacoes?${params.toString()}`, {
             method: 'GET',
+            credentials: 'include', // ADDED
             headers: {
               'Cache-Control': 'no-cache',
               'Pragma': 'no-cache',
-              'Authorization': `Bearer ${accessToken}`
+              // 'Authorization': `Bearer ${accessToken}` // REMOVED
             }
           });
           
@@ -253,15 +254,16 @@ export function useLicitacoesOtimizado() {
         return requestCache[cacheKey].data;
       }
       
-      // Obter token de autenticau00e7u00e3o
-      const accessToken = localStorage.getItem('accessToken');
+      // Obter token de autenticau00e7u00e3o - REMOVED
+      // const accessToken = localStorage.getItem('accessToken');
       
       const statsResponse = await fetch('/api/licitacoes?estatisticas=true', {
         method: 'GET',
+        credentials: 'include', // ADDED
         headers: {
           'Cache-Control': 'no-cache',
           'Pragma': 'no-cache',
-          'Authorization': `Bearer ${accessToken}`
+          // 'Authorization': `Bearer ${accessToken}` // REMOVED
         }
       });
       
@@ -310,14 +312,15 @@ export function useLicitacoesOtimizado() {
     try {
       setIsLoading(true);
       
-      // Obter token de autenticau00e7u00e3o
-      const accessToken = localStorage.getItem('accessToken');
+      // Obter token de autenticau00e7u00e3o - REMOVED
+      // const accessToken = localStorage.getItem('accessToken');
       
       const response = await fetch('/api/licitacoes', {
         method: 'POST',
+        credentials: 'include', // ADDED
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`
+          // 'Authorization': `Bearer ${accessToken}` // REMOVED
         },
         body: JSON.stringify(novaLicitacao)
       });
@@ -351,14 +354,15 @@ export function useLicitacoesOtimizado() {
     try {
       setIsLoading(true);
       
-      // Obter token de autenticau00e7u00e3o
-      const accessToken = localStorage.getItem('accessToken');
+      // Obter token de autenticau00e7u00e3o - REMOVED
+      // const accessToken = localStorage.getItem('accessToken');
       
       const response = await fetch(`/api/licitacoes/${id}`, {
         method: 'PUT',
+        credentials: 'include', // ADDED
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${accessToken}`
+          // 'Authorization': `Bearer ${accessToken}` // REMOVED
         },
         body: JSON.stringify(dadosAtualizados)
       });
@@ -392,13 +396,14 @@ export function useLicitacoesOtimizado() {
     try {
       setIsLoading(true);
       
-      // Obter token de autenticau00e7u00e3o
-      const accessToken = localStorage.getItem('accessToken');
+      // Obter token de autenticau00e7u00e3o - REMOVED
+      // const accessToken = localStorage.getItem('accessToken');
       
       const response = await fetch(`/api/licitacoes/${id}`, {
         method: 'DELETE',
+        credentials: 'include', // ADDED
         headers: {
-          'Authorization': `Bearer ${accessToken}`
+          // 'Authorization': `Bearer ${accessToken}` // REMOVED
         }
       });
       


### PR DESCRIPTION
This commit refactors the authentication mechanism to primarily use HTTP-only cookies for accessToken transmission and management, enhancing security and addressing 401 unauthorized errors, particularly during file uploads.

Key changes:

1.  **Backend API Token Extraction:**
    *   Modified document-related API routes (`app/api/documentos/**`) and user-related API routes (`app/api/users/**`) to extract the JWT token primarily from the `accessToken` HTTP-only cookie.
    *   Added a fallback to check the `Authorization: Bearer <token>` header to support transitions or specific clients.

2.  **Frontend Token Handling (`hooks/useAuth.tsx`):**
    *   Removed the storage of `accessToken` in `localStorage` from `login()` and `refreshToken()` functions.
    *   Adjusted initial auth state checks to rely on the `refreshToken` cookie and refresh mechanism rather than `localStorage` for `accessToken`.

3.  **Frontend Data Fetching Hooks:**
    *   Updated `hooks/useDocuments.ts`, `hooks/useLicitacoesOtimizado.ts`, and `hooks/useLicitacoes.ts` to:
        *   Remove manual retrieval of `accessToken` from `localStorage`.
        *   Remove manual setting of the `Authorization` header.
        *   Include `credentials: 'include'` in all `fetch` calls to ensure cookies are sent with API requests.

4.  **Backend Login/Refresh API Responses:**
    *   Modified `/api/auth/login` and `/api/auth/refresh` to no longer include the `accessToken` in their JSON response bodies. The HTTP-only cookie is now the sole delivery method for the `accessToken`.

This new approach centralizes token handling via secure HTTP-only cookies, reducing XSS vulnerabilities and ensuring a more professional and reliable authentication system. The resolution of 401 errors now strongly depends on the correct and consistent configuration of `JWT_SECRET` and `JWT_REFRESH_SECRET` in the backend environment.