### PR TITLE
Fix: Resolve API route slug name conflict for oportunidade itens

### DIFF
--- a/app/api/comercial/oportunidades/[id]/itens/route.ts
+++ b/app/api/comercial/oportunidades/[id]/itens/route.ts
@@ -23,9 +23,9 @@ function formatOportunidadeItem(item: any) {
 // GET - Listar itens de uma oportunidade
 export async function GET(
   request: NextRequest,
-  { params }: { params: { oportunidadeId: string } }
+  { params }: { params: { id: string } } // Alterado para 'id'
 ) {
-  const { oportunidadeId } = params;
+  const { id: oportunidadeId } = params; // Renomeado para oportunidadeId para clareza interna
   if (!oportunidadeId) {
     return NextResponse.json({ error: 'ID da oportunidade é obrigatório' }, { status: 400 });
   }
@@ -50,9 +50,9 @@ export async function GET(
 // POST - Adicionar um novo item a uma oportunidade
 export async function POST(
   request: NextRequest,
-  { params }: { params: { oportunidadeId: string } }
+  { params }: { params: { id: string } } // Alterado para 'id'
 ) {
-  const { oportunidadeId } = params;
+  const { id: oportunidadeId } = params; // Renomeado para oportunidadeId para clareza interna
   if (!oportunidadeId) {
     return NextResponse.json({ error: 'ID da oportunidade é obrigatório na URL' }, { status: 400 });
   }


### PR DESCRIPTION
Standardizes the dynamic parameter for opportunity IDs to `[id]` across related routes. The route for opportunity items was changed from
`app/api/comercial/oportunidades/[oportunidadeId]/itens/route.ts` to
`app/api/comercial/oportunidades/[id]/itens/route.ts`.

The route handler code was updated to reflect this change in parameter name, ensuring consistency with `app/api/comercial/oportunidades/[id]/route.ts`.

This fixes an error where Next.js would report:
'You cannot use different slug names for the same dynamic path'.