### PR TITLE
Fix: Resolve conflito de slug name em rotas de Etapas da Licitação

### DIFF
--- a/app/api/licitacoes/[id]/etapas/[etapaId]/route.ts
+++ b/app/api/licitacoes/[id]/etapas/[etapaId]/route.ts
@@ -65,9 +65,9 @@ function formatEtapaForFrontend(etapa: EtapaFromDB): EtapaFrontend {
 // GET - Obter uma etapa específica (opcional, mas bom para consistência)
 export async function GET(
   request: NextRequest,
-  { params }: { params: { licitacaoId: string; etapaId: string } }
+  { params }: { params: { id: string; etapaId: string } } // Alterado licitacaoId para id
 ) {
-  const { licitacaoId, etapaId } = params;
+  const { id: licitacaoId, etapaId } = params; // Renomeado id para licitacaoId
   if (!licitacaoId || !etapaId) {
     return NextResponse.json({ error: 'ID da Licitação e ID da Etapa são obrigatórios' }, { status: 400 });
   }
@@ -99,9 +99,9 @@ export async function GET(
 // PUT - Atualizar uma etapa específica
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { licitacaoId: string; etapaId: string } }
+  { params }: { params: { id: string; etapaId: string } } // Alterado licitacaoId para id
 ) {
-  const { licitacaoId, etapaId } = params;
+  const { id: licitacaoId, etapaId } = params; // Renomeado id para licitacaoId
   if (!licitacaoId || !etapaId) {
     return NextResponse.json({ error: 'ID da Licitação e ID da Etapa são obrigatórios' }, { status: 400 });
   }
@@ -187,9 +187,9 @@ export async function PUT(
 // DELETE - Excluir uma etapa específica
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { licitacaoId: string; etapaId: string } }
+  { params }: { params: { id: string; etapaId: string } } // Alterado licitacaoId para id
 ) {
-  const { licitacaoId, etapaId } = params;
+  const { id: licitacaoId, etapaId } = params; // Renomeado id para licitacaoId
   if (!licitacaoId || !etapaId) {
     return NextResponse.json({ error: 'ID da Licitação e ID da Etapa são obrigatórios' }, { status: 400 });
   }

--- a/app/api/licitacoes/[id]/etapas/route.ts
+++ b/app/api/licitacoes/[id]/etapas/route.ts
@@ -62,9 +62,9 @@ function formatEtapaForFrontend(etapa: EtapaFromDB): EtapaFrontend {
 // GET - Listar todas as etapas de uma licitação
 export async function GET(
   request: NextRequest,
-  { params }: { params: { licitacaoId: string } }
+  { params }: { params: { id: string } } // Alterado para id
 ) {
-  const { licitacaoId } = params;
+  const { id: licitacaoId } = params; // Renomeado id para licitacaoId
   if (!licitacaoId) {
     return NextResponse.json({ error: 'ID da Licitação é obrigatório' }, { status: 400 });
   }
@@ -94,9 +94,9 @@ export async function GET(
 // POST - Adicionar uma nova etapa a uma licitação
 export async function POST(
   request: NextRequest,
-  { params }: { params: { licitacaoId: string } }
+  { params }: { params: { id: string } } // Alterado para id
 ) {
-  const { licitacaoId } = params;
+  const { id: licitacaoId } = params; // Renomeado id para licitacaoId
   if (!licitacaoId) {
     return NextResponse.json({ error: 'ID da Licitação é obrigatório na URL' }, { status: 400 });
   }


### PR DESCRIPTION
Padroniza o parâmetro dinâmico para o ID da licitação como `[id]` nas rotas de etapas, alinhando com as outras rotas de licitação e corrigindo um erro de inicialização do Next.js.

Alterações:
- Renomeei o diretório `app/api/licitacoes/[licitacaoId]/etapas/` para `app/api/licitacoes/[id]/etapas/`.
- Renomeei o diretório `app/api/licitacoes/[licitacaoId]/etapas/[etapaId]/` para `app/api/licitacoes/[id]/etapas/[etapaId]/`.
- Atualizei o código nos respectivos arquivos `route.ts` para usar `params.id` como `licitacaoId`.