### PR TITLE
Fix: Resolve conflito de slug name em rotas de Contatos do Órgão

### DIFF
--- a/app/api/licitacoes/orgaos/[id]/contatos/[contatoId]/route.ts
+++ b/app/api/licitacoes/orgaos/[id]/contatos/[contatoId]/route.ts
@@ -39,9 +39,9 @@ function formatContatoForFrontend(contato: OrgaoContatoFromDB): OrgaoContatoFron
 // GET - Obter um contato específico de um órgão
 export async function GET(
   request: NextRequest,
-  { params }: { params: { orgaoId: string; contatoId: string } }
+  { params }: { params: { id: string; contatoId: string } } // Alterado orgaoId para id
 ) {
-  const { orgaoId, contatoId } = params;
+  const { id: orgaoId, contatoId } = params; // Renomeado id para orgaoId
   if (!orgaoId || !contatoId) {
     return NextResponse.json({ error: 'ID do Órgão e ID do Contato são obrigatórios' }, { status: 400 });
   }
@@ -67,9 +67,9 @@ export async function GET(
 // PUT - Atualizar um contato específico de um órgão
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { orgaoId: string; contatoId: string } }
+  { params }: { params: { id: string; contatoId: string } } // Alterado orgaoId para id
 ) {
-  const { orgaoId, contatoId } = params;
+  const { id: orgaoId, contatoId } = params; // Renomeado id para orgaoId
   if (!orgaoId || !contatoId) {
     return NextResponse.json({ error: 'ID do Órgão e ID do Contato são obrigatórios' }, { status: 400 });
   }
@@ -116,9 +116,9 @@ export async function PUT(
 // DELETE - Excluir um contato específico de um órgão
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { orgaoId: string; contatoId: string } }
+  { params }: { params: { id: string; contatoId: string } } // Alterado orgaoId para id
 ) {
-  const { orgaoId, contatoId } = params;
+  const { id: orgaoId, contatoId } = params; // Renomeado id para orgaoId
   if (!orgaoId || !contatoId) {
     return NextResponse.json({ error: 'ID do Órgão e ID do Contato são obrigatórios' }, { status: 400 });
   }

--- a/app/api/licitacoes/orgaos/[id]/contatos/route.ts
+++ b/app/api/licitacoes/orgaos/[id]/contatos/route.ts
@@ -43,9 +43,9 @@ function formatContatoForFrontend(contato: OrgaoContatoFromDB): OrgaoContatoFron
 // GET - Listar todos os contatos de um órgão
 export async function GET(
   request: NextRequest,
-  { params }: { params: { orgaoId: string } }
+  { params }: { params: { id: string } } // Alterado para id
 ) {
-  const { orgaoId } = params;
+  const { id: orgaoId } = params; // Renomeado id para orgaoId
   if (!orgaoId) {
     return NextResponse.json({ error: 'ID do Órgão é obrigatório' }, { status: 400 });
   }
@@ -68,9 +68,9 @@ export async function GET(
 // POST - Adicionar um novo contato a um órgão
 export async function POST(
   request: NextRequest,
-  { params }: { params: { orgaoId: string } }
+  { params }: { params: { id: string } } // Alterado para id
 ) {
-  const { orgaoId } = params;
+  const { id: orgaoId } = params; // Renomeado id para orgaoId
   if (!orgaoId) {
     return NextResponse.json({ error: 'ID do Órgão é obrigatório na URL' }, { status: 400 });
   }


### PR DESCRIPTION
Padroniza o parâmetro dinâmico para o ID do órgão como `[id]` nas rotas de seus contatos, alinhando com a rota do próprio órgão (`/orgaos/[id]`) e corrigindo um erro de inicialização do Next.js.

Alterações:
- O diretório `app/api/licitacoes/orgaos/[orgaoId]/contatos/` foi alterado para `app/api/licitacoes/orgaos/[id]/contatos/`.
- O diretório `app/api/licitacoes/orgaos/[orgaoId]/contatos/[contatoId]/` foi alterado para `app/api/licitacoes/orgaos/[id]/contatos/[contatoId]/`.
- Atualizei o código nos respectivos arquivos `route.ts` para usar `params.id` como `orgaoId`.